### PR TITLE
Made Default API validations to be config-driven.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ sections = api web
 [api]
 api_url = http://api.openweathermap.org/data/2.5/
 
+[api_validation]
+validate_status_code = True
+validate_headers = True
+validate_body = True
+fail_if_field_is_missing = True
+
 [web]
 app_url = https://openweathermap.org/
 webdriver_folder = /home/test/web/webdrivers/
@@ -81,7 +87,14 @@ for `global` section:
 for `web` section:
 
 - `webdriver_default_wait_time = 20` - Time to wait until element appears on the page (default is 20)
-- `webdriver_implicit_wait_time = 60` -Webdriver implicit wait time (default is 60)
+- `webdriver_implicit_wait_time = 60` - Webdriver implicit wait time (default is 60)
+
+for `api` the `api_validation` section is optional with the following optional parameters:
+
+- `validate_status_code = True` - Should the API validator verify response status code (default is True)
+- `validate_headers = True` - Should the API validator verify response headers (default is True)
+- `validate_body = True` - Should the API validator verify response body (default is True)
+- `fail_if_field_is_missing = True` - Should the API validator raise exception if some field from model is absent in response (default is True)
 
 #### Access Facade API
 

--- a/common/libs/config_parser/section/api_section.py
+++ b/common/libs/config_parser/section/api_section.py
@@ -1,19 +1,25 @@
-from common.libs.config_parser.section.base_section import ConfigSection
+from typing import Optional
 
-API_SECTION = "api"
+from common.libs.config_parser.section.base_section import ConfigSection
+from common.libs.config_parser.section.api_validation_section import APIValidationSection
 
 
 class APISection(ConfigSection):
     """Class responsible for api section parsing."""
 
+    SECTION_NAME = 'api'
+
     def __init__(self, config, custom_args):
         """Basic initialization."""
 
         self.api_url = None
+        self.api_validation_settings: Optional[APIValidationSection] = None
         self.config = config
         self.custom_args = custom_args
 
-        super().__init__(config, API_SECTION, custom_args=custom_args)
+        super().__init__(config, self.SECTION_NAME, custom_args=custom_args)
+
+        self._tune_api_validations()
 
     def _configure_section(self):
         """Divide settings according to their types.
@@ -38,6 +44,10 @@ class APISection(ConfigSection):
 
         if self.custom_args is not None:
             self._tune_custom_args()
+
+    def _tune_api_validations(self):
+        setattr(self, f"{APIValidationSection.SECTION_NAME}_settings", APIValidationSection(self.config,
+                                                                                            self.custom_args))
 
     def _check_settings(self):
         pass

--- a/common/libs/config_parser/section/api_validation_section.py
+++ b/common/libs/config_parser/section/api_validation_section.py
@@ -1,0 +1,58 @@
+from configparser import ConfigParser
+
+from common.libs.config_parser.config_error import ConfigError
+from common.libs.config_parser.section.base_section import ConfigSection
+
+
+class APIValidationSection(ConfigSection):
+    """Class responsible for api validation rules section parsing."""
+
+    SECTION_NAME = 'api_validation'
+
+    def __init__(self, config, custom_args):
+        """Basic initialization."""
+        self.validate_status_code = True
+        self.validate_headers = True
+        self.validate_body = True
+        self.fail_if_field_is_missing = True
+        self.config: ConfigParser = config
+        self.custom_args = custom_args
+
+        super().__init__(config, self.SECTION_NAME, custom_args=custom_args)
+
+    def _configure_section(self):
+        """Divide settings according to their types.
+        Set mandatory,comma separated list, space separated list, str,
+        bool, int, list of nodes fields if it is necessary.
+        """
+        self._mandatory_fields = []
+        self._str_fields = []
+        self._int_fields = []
+        self._bool_fields = ['validate_status_code', 'validate_headers', 'validate_body',
+                             'fail_if_field_is_missing']
+        self._settings = self._str_fields + self._int_fields + self._bool_fields
+
+    def _load_from_config(self):
+        """Add a section to initial config object if it absences to support optional logic for section and
+        execute default _load_from_config behaviour"""
+        try:
+            self.check_if_section_exists(self.config, self.SECTION_NAME, None)
+        except ConfigError:
+            self.config.add_section(self.SECTION_NAME)
+        super()._load_from_config()
+
+    def to_dict(self):
+        """Convert to dictionary."""
+        return {field: getattr(self, field, None) for field in self._settings}
+
+    def _perform_custom_tunings(self):
+        """Perform custom tunings for obtained settings."""
+        for setting in self._settings:
+            if setting in self._untuned_settings:
+                setattr(self, setting, self._untuned_settings[setting])
+
+        if self.custom_args is not None:
+            self._tune_custom_args()
+
+    def _check_settings(self):
+        pass

--- a/common/libs/config_parser/section/global_section.py
+++ b/common/libs/config_parser/section/global_section.py
@@ -23,10 +23,12 @@ class GlobalSection(ConfigSection, BaseGlobalSection):
     """Class representing a global section of the configuration file.
     """
 
+    SECTION_NAME = 'global'
+
     def __init__(self, config, custom_args=None):
         self.custom_args = custom_args
         BaseGlobalSection.__init__(self)
-        ConfigSection.__init__(self, config, 'global', custom_args=self.custom_args)
+        ConfigSection.__init__(self, config, self.SECTION_NAME, custom_args=self.custom_args)
 
     def to_dict(self):
         """Convert to dictionary."""

--- a/common/libs/config_parser/section/web_section.py
+++ b/common/libs/config_parser/section/web_section.py
@@ -3,8 +3,6 @@ import os
 from common.libs.config_parser.section.base_section import ConfigSection
 from common.libs.config_parser.config_error import ConfigError
 
-WEB_SECTION = "web"
-
 BROWSER_SETTINGS_MAPPING = {"chrome": "chrome_driver_name",
                             "firefox": "firefox_driver_name"}
 
@@ -13,6 +11,8 @@ ALLOWED_BROWSER_LIST = ["chrome", "firefox"]
 
 class WebSection(ConfigSection):
     """Class responsible for ui section parsing."""
+
+    SECTION_NAME = "web"
 
     def __init__(self, config, custom_args):
         """Basic initialization."""
@@ -27,7 +27,7 @@ class WebSection(ConfigSection):
         self.config = config
         self.custom_args = custom_args
 
-        super().__init__(config, WEB_SECTION, custom_args=custom_args)
+        super().__init__(config, self.SECTION_NAME, custom_args=custom_args)
 
     def _configure_section(self):
         """Divide settings according to their types.

--- a/common/libs/exception_thread/ex_thread.py
+++ b/common/libs/exception_thread/ex_thread.py
@@ -2,10 +2,10 @@ import threading
 import traceback
 import queue
 from multiprocessing import TimeoutError
-import logging
 
-logger = logging.getLogger("thread")
-logger.setLevel("WARNING")
+from common.scaf import get_logger
+
+logger = get_logger(__name__)
 
 
 def run_commands_in_thread(commands, args=()):

--- a/common/libs/helpers/gmail_manager.py
+++ b/common/libs/helpers/gmail_manager.py
@@ -1,7 +1,8 @@
 import imaplib
-import logging
 
-log = logging.getLogger(__name__)
+from common.scaf import get_logger
+
+logger = get_logger(__name__)
 
 
 class GmailManager:
@@ -20,17 +21,17 @@ class GmailManager:
 
     def get_emails(self, subject):
         emails = []
-        log.info(f"Getting messages from inbox with subject '{subject}'")
+        logger.info(f"Getting messages from inbox with subject '{subject}'")
         self.mail.select('inbox')
         result, data = self.mail.search(None, f'(UNSEEN SUBJECT "{subject}")')
-        log.info(f"Result {result}")
+        logger.info(f"Result {result}")
         uids = data[0].split()
         if result == 'OK':
             for uid in uids:
                 result, email = self.mail.fetch(uid, '(RFC822)')
                 email_body = email[0][1].decode('utf-8')
                 emails.append(email_body)
-        log.info(f"Collected {len(emails)} emails")
+        logger.info(f"Collected {len(emails)} emails")
         return emails
 
     def remove_emails(self):
@@ -40,7 +41,7 @@ class GmailManager:
         for uid in uids:
             self.mail.store(uid, '+FLAGS', '\\Deleted')
         self.mail.expunge()
-        log.info(f"Deleting all emails in {self.email}")
+        logger.info(f"Deleting all emails in {self.email}")
 
     def wait_until_email_appears(self, subject="", timeout=20):
         import time

--- a/common/libs/helpers/waiters.py
+++ b/common/libs/helpers/waiters.py
@@ -1,9 +1,10 @@
 from functools import wraps
 from operator import eq, lt, ne, gt
 from time import sleep
-import logging
 
-logger = logging.getLogger(__name__)
+from common.scaf import get_logger
+
+logger = get_logger(__name__)
 
 
 def wait_for_return_value(

--- a/common/libs/logger.py
+++ b/common/libs/logger.py
@@ -85,11 +85,14 @@ class SCAFLogger:
 
         self.reset_counters()
 
+    def debug(self, message: str):
+        self.logger.debug(message)
+
     def info(self, message: str):
         self.logger.info(message)
 
-    def debug(self, message: str):
-        self.logger.debug(message)
+    def warning(self, message: str):
+        self.logger.warning(message)
 
     def exception(self, message:str):
         self.logger.exception(message)

--- a/common/rest_qa_api/base_endpoint.py
+++ b/common/rest_qa_api/base_endpoint.py
@@ -397,7 +397,7 @@ class ResponseConverterMixin:
         response_container.status_code = response_container.raw_response.status_code
 
 
-@scaf_dataclass(repr=True, eq=False, init=False)
+@scaf_dataclass(repr=True, eq=False)
 class BaseResponseModel(ResponseConverterMixin, ResponseValidatorMixin, metaclass=ABCMeta):
     """Abstract Base class for HTTP Response model description.
 

--- a/config/config.ini
+++ b/config/config.ini
@@ -7,6 +7,12 @@ sections = api web
 [api]
 api_url = http://api.openweathermap.org/data/2.5/
 
+[api_validation]
+validate_status_code = True
+validate_headers = True
+validate_body = True
+fail_if_field_is_missing = True
+
 [web]
 app_url = https://openweathermap.org/
 webdriver_folder = /Users/test/Downloads/


### PR DESCRIPTION
Updated config sections to use the same SECTION_NAME approach
Added api_validation section to config.ini with api dependency
Added ApiValidationSection config section
Added configure_validator method to ResponseValidatorMixin to support endpoint-based validations configuration
Replaced custom logger with scaf logger in some utils
Added warning log level to scaf logger