### PR TITLE
Made Default API validations to be config-driven

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ sections = api web
 [api]
 api_url = http://api.openweathermap.org/data/2.5/
 
+[api_validation]
+validate_status_code = True
+validate_headers = True
+validate_body = True
+validate_is_field_missing = True
+
 [web]
 app_url = https://openweathermap.org/
 webdriver_folder = /home/test/web/webdrivers/
@@ -81,7 +87,14 @@ for `global` section:
 for `web` section:
 
 - `webdriver_default_wait_time = 20` - Time to wait until element appears on the page (default is 20)
-- `webdriver_implicit_wait_time = 60` -Webdriver implicit wait time (default is 60)
+- `webdriver_implicit_wait_time = 60` - Webdriver implicit wait time (default is 60)
+
+for `api` the `api_validation` section is optional with the following optional parameters:
+
+- `validate_status_code = True` - Should the API validator verify response status code (default is True)
+- `validate_headers = True` - Should the API validator verify response headers (default is True)
+- `validate_body = True` - Should the API validator verify response body (default is True)
+- `validate_is_field_missing = True` - Should the API validator raise exception if some field from model is absent in response (default is True)
 
 #### Access Facade API
 

--- a/common/libs/config_manager.py
+++ b/common/libs/config_manager.py
@@ -1,4 +1,6 @@
 import os
+
+from common.libs.config_parser.config_dto import APIValidationDTO
 from common.libs.config_parser.config_parser import ParseConfig
 from common.libs.helpers.singleton import Singleton
 
@@ -16,3 +18,8 @@ class ConfigManager(metaclass=Singleton):
 
     def update_config(self, custom_args):
         self.config = ParseConfig(self.path_to_config, custom_args)
+
+    def get_api_validations(self) -> APIValidationDTO:
+        settings = self.config.api_settings.api_validation_settings
+        return APIValidationDTO(settings.validate_status_code, settings.validate_headers,
+                                settings.validate_body, settings.validate_is_field_missing)

--- a/common/libs/config_parser/config_dto.py
+++ b/common/libs/config_parser/config_dto.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class APIValidationDTO:
+    check_status_code: bool
+    check_headers: bool
+    check_body: bool
+    check_is_field_missing: bool

--- a/common/libs/config_parser/section/api_section.py
+++ b/common/libs/config_parser/section/api_section.py
@@ -1,19 +1,26 @@
-from common.libs.config_parser.section.base_section import ConfigSection
+from typing import Optional
 
-API_SECTION = "api"
+from common.libs.config_parser.section.base_section import ConfigSection
+from common.libs.config_parser.section.api_validation_section import APIValidationSection
 
 
 class APISection(ConfigSection):
     """Class responsible for api section parsing."""
 
+    SECTION_NAME = 'api'
+
     def __init__(self, config, custom_args):
         """Basic initialization."""
 
         self.api_url = None
+        self.api_validation_settings: Optional[APIValidationSection] = None
         self.config = config
         self.custom_args = custom_args
+        self._settings = []
 
-        super().__init__(config, API_SECTION, custom_args=custom_args)
+        super().__init__(config, self.SECTION_NAME, custom_args=custom_args)
+
+        self._tune_api_validations()
 
     def _configure_section(self):
         """Divide settings according to their types.
@@ -38,6 +45,10 @@ class APISection(ConfigSection):
 
         if self.custom_args is not None:
             self._tune_custom_args()
+
+    def _tune_api_validations(self):
+        setattr(self, f"{APIValidationSection.SECTION_NAME}_settings", APIValidationSection(self.config,
+                                                                                            self.custom_args))
 
     def _check_settings(self):
         pass

--- a/common/libs/config_parser/section/api_validation_section.py
+++ b/common/libs/config_parser/section/api_validation_section.py
@@ -1,0 +1,59 @@
+from configparser import ConfigParser
+
+from common.libs.config_parser.config_error import ConfigError
+from common.libs.config_parser.section.base_section import ConfigSection
+
+
+class APIValidationSection(ConfigSection):
+    """Class responsible for api validation rules section parsing."""
+
+    SECTION_NAME = 'api_validation'
+
+    def __init__(self, config, custom_args):
+        """Basic initialization."""
+        self.validate_status_code = True
+        self.validate_headers = True
+        self.validate_body = True
+        self.validate_is_field_missing = True
+        self.config: ConfigParser = config
+        self.custom_args = custom_args
+        self._settings = []
+
+        super().__init__(config, self.SECTION_NAME, custom_args=custom_args)
+
+    def _configure_section(self):
+        """Divide settings according to their types.
+        Set mandatory,comma separated list, space separated list, str,
+        bool, int, list of nodes fields if it is necessary.
+        """
+        self._mandatory_fields = []
+        self._str_fields = []
+        self._int_fields = []
+        self._bool_fields = ['validate_status_code', 'validate_headers', 'validate_body',
+                             'validate_is_field_missing']
+        self._settings = self._str_fields + self._int_fields + self._bool_fields
+
+    def _load_from_config(self):
+        """Add a section to initial config object if it absences to support optional logic for section and
+        execute default _load_from_config behaviour"""
+        try:
+            self.check_if_section_exists(self.config, self.SECTION_NAME, None)
+        except ConfigError:
+            self.config.add_section(self.SECTION_NAME)
+        super()._load_from_config()
+
+    def to_dict(self):
+        """Convert to dictionary."""
+        return {field: getattr(self, field, None) for field in self._settings}
+
+    def _perform_custom_tunings(self):
+        """Perform custom tunings for obtained settings."""
+        for setting in self._settings:
+            if setting in self._untuned_settings:
+                setattr(self, setting, self._untuned_settings[setting])
+
+        if self.custom_args is not None:
+            self._tune_custom_args()
+
+    def _check_settings(self):
+        pass

--- a/common/libs/config_parser/section/global_section.py
+++ b/common/libs/config_parser/section/global_section.py
@@ -23,10 +23,13 @@ class GlobalSection(ConfigSection, BaseGlobalSection):
     """Class representing a global section of the configuration file.
     """
 
+    SECTION_NAME = 'global'
+
     def __init__(self, config, custom_args=None):
         self.custom_args = custom_args
+        self._settings = []
         BaseGlobalSection.__init__(self)
-        ConfigSection.__init__(self, config, 'global', custom_args=self.custom_args)
+        ConfigSection.__init__(self, config, self.SECTION_NAME, custom_args=self.custom_args)
 
     def to_dict(self):
         """Convert to dictionary."""

--- a/common/libs/config_parser/section/web_section.py
+++ b/common/libs/config_parser/section/web_section.py
@@ -14,6 +14,8 @@ ALLOWED_BROWSER_LIST = ["chrome", "firefox"]
 class WebSection(ConfigSection):
     """Class responsible for ui section parsing."""
 
+    SECTION_NAME = 'web'
+
     def __init__(self, config, custom_args):
         """Basic initialization."""
         self.app_url = None
@@ -26,8 +28,9 @@ class WebSection(ConfigSection):
         self.browser = 'chrome'
         self.config = config
         self.custom_args = custom_args
+        self._settings = []
 
-        super().__init__(config, WEB_SECTION, custom_args=custom_args)
+        super().__init__(config, self.SECTION_NAME, custom_args=custom_args)
 
     def _configure_section(self):
         """Divide settings according to their types.
@@ -71,4 +74,3 @@ class WebSection(ConfigSection):
         driver_variable = BROWSER_SETTINGS_MAPPING[self.browser]
         driver_path = os.path.join(self.webdriver_folder, getattr(self, driver_variable))
         return driver_path
-

--- a/common/libs/logger.py
+++ b/common/libs/logger.py
@@ -88,6 +88,9 @@ class SCAFLogger:
     def info(self, message: str):
         self.logger.info(message)
 
+    def warning(self, message: str):
+        self.logger.warning(message)
+
     def debug(self, message: str):
         self.logger.debug(message)
 

--- a/common/rest_qa_api/base_endpoint.py
+++ b/common/rest_qa_api/base_endpoint.py
@@ -2,9 +2,12 @@ import json
 import inspect
 from copy import deepcopy, copy
 from abc import ABCMeta, abstractmethod
+from dataclasses import InitVar
 from typing import Any, Dict, Union, Optional, Tuple, Callable, List, Type
 
 from common import scaf
+from common.libs.config_manager import ConfigManager
+from common.libs.config_parser.config_dto import APIValidationDTO
 from common.rest_qa_api import default_exclude_list, method_exclude_lists
 from common.rest_qa_api.rest_checkers import BaseRESTCheckers
 from common.rest_qa_api.rest_exceptions import MethodNotSupportedByEndpoint, DataclassNameError, \
@@ -26,8 +29,41 @@ class ResponseValidatorMixin:
     During the verification, all errors are saved in self.errors.
     2 types of validations are supported: default validation according to the model and custom user checkers.
 
-    It's possible to provide additional checkers by adding them to the custom_checkers list.
+    The default validation rules are initialized based on the config values. It is possible to override them for each
+    endpoint separately.
+    It is also possible to provide additional custom checkers by adding them to the custom_checkers list.
     """
+
+    _check_status_code = None
+    _check_headers = None
+    _check_body = None
+    _check_is_field_missing = None
+
+    def __init__(self, api_validation_section: APIValidationDTO):
+        self._check_status_code = self._check_status_code if self._check_status_code \
+            else api_validation_section.check_status_code
+        self._check_headers = self._check_headers if self._check_headers \
+            else api_validation_section.check_headers
+        self._check_body = self._check_body if self._check_body \
+            else api_validation_section.check_body
+        self._check_is_field_missing = self._check_is_field_missing if self._check_is_field_missing \
+            else api_validation_section.check_is_field_missing
+
+    @classmethod
+    def configure_validator(cls, validate_status_code=True, validate_headers=True, validate_body=True,
+                            validate_is_field_missing=True):
+        """Performs default validators setup for endpoint if default values should be override.
+        Args:
+            validate_status_code (bool): Performs status code validation if True
+            validate_headers (bool): Performs headers validation if True
+            validate_body (bool): Performs body validation if True
+            validate_is_field_missing (bool): Fail validation if some field from model is absent in response.
+            Added for cases when response may contain only part of model's values and it is expected.
+        """
+        cls._check_status_code = validate_status_code
+        cls._check_headers = validate_headers
+        cls._check_body = validate_body
+        cls._check_is_field_missing = validate_is_field_missing
 
     def __eq__(self: Union['BaseResponseModel', 'ResponseConverterMixin', 'ResponseValidatorMixin'], model):
         """Performs object fields comparison.
@@ -62,9 +98,14 @@ class ResponseValidatorMixin:
             property_name = f'{self.raw_response.request.method.lower()}_data'
         body_to_verify = getattr(self, f'{property_name}')
         model_data = getattr(model, property_name)
-        self._validate_structure('status_code', self.status_code, model.status_code)
-        self._validate_structure(property_name, body_to_verify, model_data)
-        self._validate_structure('headers', self.headers, model.headers)
+
+        # Verify basic validation rules and perform response validation
+        if self._check_status_code:
+            self._validate_structure('status_code', self.status_code, model.status_code)
+        if self._check_headers:
+            self._validate_structure('headers', self.headers, model.headers)
+        if self._check_body:
+            self._validate_structure(property_name, body_to_verify, model_data)
         if self.custom_checkers:
             self._run_checkers()
         if self.errors["default"] or self.errors["custom"]:
@@ -101,10 +142,15 @@ class ResponseValidatorMixin:
                     try:
                         self._validate_structure(key, data_to_verify[key], model_to_verify[key])
                     except KeyError:
-                        # for case when key is absent in response
-                        self.field_nesting.append(key)
-                        self.errors["default"].append((copy(self.field_nesting), model_to_verify[key],
-                                                       "field does not present in response"))
+                        # for case when key is absent in response. If _check_is_field_missing is False
+                        # logs warning message
+                        if self._check_is_field_missing:
+                            self.field_nesting.append(key)
+                            self.errors["default"].append((copy(self.field_nesting), model_to_verify[key],
+                                                           "field does not present in response"))
+                            self.field_nesting.pop()
+                        else:
+                            logger.warning(f"The field {key} is not present in response. Please verify your model")
             else:
                 self.errors["default"].append((copy(self.field_nesting), model_to_verify, data_to_verify))
 
@@ -446,6 +492,7 @@ class BaseResponseModel(ResponseConverterMixin, ResponseValidatorMixin, metaclas
             raise DataclassNameError(cls.__name__)
         return super().__new__(cls)
 
+    config: InitVar[ConfigManager]
     _status_code: int = None
     _get_data: Any = None
     _post_data: Any = None
@@ -603,6 +650,9 @@ class BaseResponseModel(ResponseConverterMixin, ResponseValidatorMixin, metaclas
     def custom_checkers(self, custom_checkers) -> None:
         self._custom_checkers = custom_checkers
 
+    def __post_init__(self, config: ConfigManager):
+        super().__init__(config.get_api_validations())
+
     def __repr__(self):
         """Override __repr__ to support custom class representation
 
@@ -618,7 +668,7 @@ class BaseResponseModel(ResponseConverterMixin, ResponseValidatorMixin, metaclas
 
 class BaseEndpoint:
     def __init__(self, base_url: str, request_model: BaseRequestModel,
-                 response_model: BaseResponseModel, make_url_method):
+                 response_model: BaseResponseModel, make_url_method, config=ConfigManager()):
         """Class representation for the agent and container for HTTP Request/Response models
 
         Takes request model, parses it and sends to request library,
@@ -650,7 +700,8 @@ class BaseEndpoint:
         self.response_model = response_model
         self.make_url_method = make_url_method
         # Dummy container to prepare request fields
-        self._request = type("Jon_Golt", (object,), dict())()
+        self._request = type("Jon_Galt", (object,), dict())()
+        self._config = config
 
     def __getattr__(self, item):
         """Verifies if the called method presents in self.request_model.allowed_methods
@@ -704,7 +755,8 @@ class BaseEndpoint:
 
 def endpoint_factory(base_url: str, class_name: str, request_model: Type[BaseRequestModel],
                      response_model: Type[BaseResponseModel], superclass=BaseEndpoint,
-                     make_url_method=make_request_url) -> Union[Callable[[], BaseEndpoint], BaseEndpoint]:
+                     make_url_method=make_request_url, config: ConfigManager = ConfigManager()) \
+        -> Union[Callable[[], BaseEndpoint], BaseEndpoint]:
     """Factory to create class based on BaseEndpoint
 
     Attributes:
@@ -720,7 +772,7 @@ def endpoint_factory(base_url: str, class_name: str, request_model: Type[BaseReq
         :obj lambda with class which 'class_name' is inherited from 'superclass'
     """
     dummy_class = type(class_name, (superclass,), dict(request_model=request_model,
-                                                       response_model=response_model,
+                                                       response_model=response_model(config=config),
                                                        base_url=base_url,
                                                        make_url_method=make_url_method))
-    return lambda: dummy_class(base_url, request_model(), response_model(), make_url_method)
+    return lambda: dummy_class(base_url, request_model(), response_model(config=config), make_url_method)

--- a/config/config.ini
+++ b/config/config.ini
@@ -7,6 +7,12 @@ sections = api web
 [api]
 api_url = http://api.openweathermap.org/data/2.5/
 
+[api_validation]
+validate_status_code = True
+validate_headers = True
+validate_body = True
+validate_is_field_missing = False
+
 [web]
 app_url = https://openweathermap.org/
 webdriver_folder = /Users/test/Downloads/


### PR DESCRIPTION
Updated config sections to use the same SECTION_NAME approach
Added api_validation section to config.ini with api dependency
Added ApiValidationSection config section
Made ResponseValidatorMixin initialized to configure validator based on the config values globally during init
Added configure_validator method to ResponseValidatorMixin to support endpoint-based validations configuration
Added warning log level to scaf logger