### PR TITLE
Fix Builder reinitialization to clean the structure after any update.

### DIFF
--- a/common/_rest_qa_api/base_endpoint.py
+++ b/common/_rest_qa_api/base_endpoint.py
@@ -543,7 +543,7 @@ class BaseEndpoint:
 
 def endpoint_factory(base_url: str, class_name: str, request_model: Type[BaseRequestModel],
                      response_model: Type[BaseResponseModel], superclass=BaseEndpoint,
-                     make_url_method=make_request_url, config: ConfigManager = ConfigManager()) \
+                     make_url_method=make_request_url, config=None) \
         -> Union[Callable[[], BaseEndpoint], BaseEndpoint]:
     """Factory to create class based on BaseEndpoint
 
@@ -559,6 +559,8 @@ def endpoint_factory(base_url: str, class_name: str, request_model: Type[BaseReq
     Returns:
         :obj lambda with class which 'class_name' is inherited from 'superclass'
     """
+    if not config:
+        config = ConfigManager()
     dummy_class = type(class_name, (superclass,), dict(request_model=None, response_model=None, base_url=None,
                                                        make_url_method=None))
     return lambda: dummy_class(base_url, request_model=copy.deepcopy(request_model()),

--- a/common/_rest_qa_api/base_endpoint.py
+++ b/common/_rest_qa_api/base_endpoint.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 from abc import ABCMeta, abstractmethod
 from dataclasses import InitVar
@@ -560,5 +561,6 @@ def endpoint_factory(base_url: str, class_name: str, request_model: Type[BaseReq
     """
     dummy_class = type(class_name, (superclass,), dict(request_model=None, response_model=None, base_url=None,
                                                        make_url_method=None))
-    return lambda: dummy_class(base_url, request_model=request_model(), response_model=response_model(config=config),
+    return lambda: dummy_class(base_url, request_model=copy.deepcopy(request_model()),
+                               response_model=copy.deepcopy(response_model(config=config)),
                                make_url_method=make_url_method)

--- a/common/_rest_qa_api/response_validator.py
+++ b/common/_rest_qa_api/response_validator.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from common._rest_qa_api.response_converter import ResponseConverterMixin
 
 logger = logging.getLogger(__name__)
+logger.setLevel("INFO")
 
 
 class ResponseValidatorMixin:

--- a/common/_rest_qa_api/rest_checkers.py
+++ b/common/_rest_qa_api/rest_checkers.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
     from common._rest_qa_api.base_endpoint import BaseResponseModel
 
 logger = logging.getLogger(__name__)
+logger.setLevel("INFO")
 
 
 class BaseRESTCheckers:

--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,5 @@
-pytest_plugins = [
-    "common.hooks"
-]
+config = __spec__.loader.config
+if "unit_test" not in config.invocation_params.args[0] and "unit_test" not in config.invocation_dir.dirname:
+    pytest_plugins = [
+        "common.hooks"
+    ]

--- a/project/api/endpoints/daily_weather_endpoint.py
+++ b/project/api/endpoints/daily_weather_endpoint.py
@@ -41,7 +41,7 @@ class DailyWeatherEndpointBuilder:
         custom_checkers = []
 
     _DailyWeatherResponseModel.configure_validator()
-    endpoint = endpoint_factory(raw_config.project_settings.web_api_url, "DailyWeatherEndpoint",
+    endpoint = endpoint_factory(raw_config.project_settings.web_api_url, __qualname__,
                                 _DailyWeatherRequestModel, _DailyWeatherResponseModel)
 
     def get_weather_details(self, city, token):

--- a/unit_tests/rest_qa_api_tests/base_endpoint_test.py
+++ b/unit_tests/rest_qa_api_tests/base_endpoint_test.py
@@ -49,6 +49,22 @@ def test_access_public_fields():
         pytest.fail(f"DID RAISE {e}")
 
 
+def test_new_instance_inits_with_clean_models():
+    try:
+        first_instance = TestEndpointBuilder()
+        first_instance.endpoint.request_model.post_data = {"testField1": "testValue1"}
+        first_instance.endpoint.response_model.post_data = {"testField1": "testValue1"}
+        second_instance = TestEndpointBuilder()
+        assert second_instance.endpoint.request_model.post_data is None
+        assert second_instance.endpoint.response_model.post_data is SKIP
+        second_instance.endpoint.request_model.post_data = {"testField2": "testValue2"}
+        second_instance.endpoint.response_model.post_data = {"testField2": "testValue2"}
+        assert first_instance.endpoint.request_model.post_data == {"testField1": "testValue1"}
+        assert first_instance.endpoint.response_model.post_data == {"testField1": "testValue1"}
+    except Exception as e:
+        pytest.fail(f"DID RAISE {e}")
+
+
 @patch('requests.request', return_value=fake_response())
 class TestStatusCode:
 

--- a/unit_tests/rest_qa_api_tests/custom_checkers_test.py
+++ b/unit_tests/rest_qa_api_tests/custom_checkers_test.py
@@ -61,7 +61,7 @@ class TestRunCheckersBranches:
         builder.endpoint.response_model.custom_checkers.append(DummyResponseBuilder)
         with pytest.raises(Exception):
             builder.endpoint.get()
-        expected_log_message = f"fail"
+        expected_log_message = "fail"
         expected_second_log_message = f"<class 'unit_tests.rest_qa_api_tests.tests_utils.DummyResponseBuilder'> has" \
                                       f" unsupported type. Supported are functions and BaseRESTCheckers instances"
         first_message = [record for record in caplog.records if expected_log_message == record.message]
@@ -81,9 +81,14 @@ class TestCustomLogger:
             builder.endpoint.get()
         except Exception as e:
             pytest.fail(f"DID RAISE {e}")
-        expected_log_message = f"{JSONCheckers.check_status.__name__} validation passed"
-        messages = [record for record in caplog.records if expected_log_message == record.message]
-        assert len(messages) == 1, "Expected message not found in logs"
+        expected_first_log_message = f"run checker: {JSONCheckers.__name__}: "
+        expected_second_log_message = f"check that status code is {JSONCheckers.status}"
+        expected_third_log_message = f"{JSONCheckers.check_status.__name__} validation passed"
+        expected_fourth_log_message = f"{JSONCheckers.__name__} validation passed"
+        messages = [record for record in caplog.records if record.message in
+                    (expected_first_log_message, expected_second_log_message,
+                     expected_third_log_message, expected_fourth_log_message)]
+        assert len(messages) == 4, "Expected message not found in logs"
 
     def test_logging_through_customer_checker_function(self, _, response, builder, caplog):
         response.status_code = 200


### PR DESCRIPTION
Fix Builder reinitialization to clean the structure after any update. #18 
Replace string name of builder with __qualname__
Add unit test for builder init and fix unit tests for logging
Exclude Facade initialization for unit testing
Changed log level to INFO for API core